### PR TITLE
Explore protobuf to avro

### DIFF
--- a/kotlin/kroto-plus/build.gradle.kts
+++ b/kotlin/kroto-plus/build.gradle.kts
@@ -64,6 +64,8 @@ subprojects {
             implementation("javax.annotation", "javax.annotation-api", "1.3.2")
 
             implementation("org.jetbrains.kotlinx", "kotlinx-coroutines-core", "1.1.1")
+
+            implementation("org.apache.avro", "avro-protobuf", "1.9.1")
         }
     }
 

--- a/kotlin/kroto-plus/model/krotoPlusConfig.asciipb
+++ b/kotlin/kroto-plus/model/krotoPlusConfig.asciipb
@@ -1,3 +1,7 @@
 grpc_coroutines {
   # even without config, this is necessary to generate coroutine classes
 }
+proto_builders {
+    # minimum configuration necessary to generate the block builders
+    use_dsl_markers: true
+}

--- a/kotlin/kroto-plus/protobuf-avro/build.gradle.kts
+++ b/kotlin/kroto-plus/protobuf-avro/build.gradle.kts
@@ -1,0 +1,4 @@
+dependencies {
+  implementation("org.apache.avro", "avro-protobuf")
+  implementation(project(":model"))
+}

--- a/kotlin/kroto-plus/protobuf-avro/src/test/kotlin/com/spothero/krotoplus/protobufavro/ProtobufOverAvroTest.kt
+++ b/kotlin/kroto-plus/protobuf-avro/src/test/kotlin/com/spothero/krotoplus/protobufavro/ProtobufOverAvroTest.kt
@@ -8,11 +8,13 @@ import org.junit.jupiter.api.Test
 import com.grpc.v1.GrpcProtoBuilders
 import org.apache.avro.io.DecoderFactory
 import org.apache.avro.io.EncoderFactory
+import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.PipedInputStream
 import java.io.PipedOutputStream
 
 class ProtobufOverAvroTest {
+
   @Test
   fun `should get Avro Schema for Protobuf class`() {
     val expectedFields = listOf(
@@ -31,6 +33,34 @@ class ProtobufOverAvroTest {
 
     val schemaByDescriptor = ProtobufData.get().getSchema(GetFortuneRequest.getDescriptor())
     assertEquals(schemaByClass, schemaByDescriptor)
+
+    val siblingAgesField = schemaByClass.getField("sibling_ages")
+    println("field: $siblingAgesField")
+    println("schema: ${siblingAgesField.schema()}")
+
+    val siblingAgesSchema = ProtobufData.get()
+      .getSchema(GetFortuneRequest.getDescriptor().findFieldByName("sibling_ages"))
+    println("siblingAgesSchema: $siblingAgesSchema")
+
+    val schemaCacheField = ProtobufData::class.java.getDeclaredField("schemaCache")
+    schemaCacheField.trySetAccessible()
+    val schemaCache = schemaCacheField.get(ProtobufData.get()) as Map<Object, Schema>
+    for (entry in schemaCache.entries) {
+      println("obj: ${entry.key}, schema: ${entry.value.name}")
+    }
+    val schemaCacheSize = schemaCache.size
+    println("Original schemaCache size: $schemaCacheSize")
+
+    for (fieldDescriptor in GetFortuneRequest.getDescriptor().fields) {
+      println("fieldDescriptor: $fieldDescriptor, type: ${fieldDescriptor.type}, isRepeated: ${fieldDescriptor.isRepeated}")
+      if (fieldDescriptor.isMapField) {
+        println("mapField: $fieldDescriptor, messageType: ${fieldDescriptor.messageType.name}")
+        val mapElementSchema = ProtobufData.get().getSchema(fieldDescriptor.messageType)
+        println("mapElementSchema: $mapElementSchema")
+        val newSchemaCacheSize = schemaCache.size
+        println("New schemaCache size: $newSchemaCacheSize")
+      }
+    }
   }
 
   @Test
@@ -43,35 +73,38 @@ class ProtobufOverAvroTest {
         year = 1992
       }
       carNickname = "Greatest. Car. Ever."
+      bikeFrameSizeCm = 99 // Excluding this field works, but defaults to 0
       addAllFingerLengths(listOf(42, 24))
-      putAllSiblingAges(mapOf(
-        "Larry" to 30,
-        "Moe" to 31,
-        "Curly" to 32
-      ))
+//      putAllSiblingAges(mapOf(
+//        "Larry" to 30,
+//        "Moe" to 31,
+//        "Curly" to 32
+//      ))
     }
+
+    // SpecificData::getClass can't handle a protobuf map.  Protobuf treats map entries
+    // as messages with 'key' and 'value' properties.  They are com.google.protobuf.MapEntry
+    // objects and given names like 'com.grpc.v1.GetFortuneRequest.SiblingAgesEntry'.
+    // SpecificData::getClass isn't set up to handle these map entries and fails to detect
+    // the class.  That method is written with a recursive resolver which assumes the recursion
+    // will terminate, but never does.
 
     val getFortuneRequestSchema = ProtobufData.get().getSchema(GetFortuneRequest.getDescriptor())
 
     // Binary streams to write to, then read from
-    val outputStream = PipedOutputStream()
-    val inputStream = PipedInputStream(outputStream)
-
-    // binary en/de-coders for writing to and reading from streams
+    val outputStream = ByteArrayOutputStream(1024)
     val binaryEncoder = EncoderFactory.get().binaryEncoder(outputStream, null)
-    val binaryDecoder = DecoderFactory.get().binaryDecoder(inputStream, null)
-
-    // Avro writer and reader
     val datumWriter = ProtobufData.get().createDatumWriter(getFortuneRequestSchema)
-    val datumReader = ProtobufData.get().createDatumReader(getFortuneRequestSchema)
-
-    // WHEN we write the source and read it back out
     datumWriter.write(sourceGetFortune, binaryEncoder)
     binaryEncoder.flush()
     outputStream.flush()
     outputStream.close()
-    val readGetFortune = datumReader.read(null, binaryDecoder)
+    val binaryDataArray = outputStream.toByteArray()
 
+    val binaryDecoder = DecoderFactory.get().binaryDecoder(binaryDataArray, null)
+    val datumReader = ProtobufData.get().createDatumReader(getFortuneRequestSchema)
+
+    val readGetFortune = datumReader.read(null, binaryDecoder)
     // Source and Read values should be equal
     assertEquals(sourceGetFortune, readGetFortune)
     println(readGetFortune)

--- a/kotlin/kroto-plus/protobuf-avro/src/test/kotlin/com/spothero/krotoplus/protobufavro/ProtobufOverAvroTest.kt
+++ b/kotlin/kroto-plus/protobuf-avro/src/test/kotlin/com/spothero/krotoplus/protobufavro/ProtobufOverAvroTest.kt
@@ -1,0 +1,79 @@
+package com.spothero.krotoplus.protobufavro
+
+import com.grpc.v1.GetFortuneRequest
+import org.apache.avro.Schema
+import org.apache.avro.protobuf.ProtobufData
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import com.grpc.v1.GrpcProtoBuilders
+import org.apache.avro.io.DecoderFactory
+import org.apache.avro.io.EncoderFactory
+import java.io.ByteArrayOutputStream
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+
+class ProtobufOverAvroTest {
+  @Test
+  fun `should get Avro Schema for Protobuf class`() {
+    val expectedFields = listOf(
+      "name",
+      "optional_car",
+      "car_nickname",
+      "bike_frame_size_cm",
+      "finger_lengths",
+      "sibling_ages"
+    )
+
+    val schemaByClass = ProtobufData.get().getSchema(GetFortuneRequest::class.java)
+
+    val actualFieldNames = schemaByClass.fields.map(Schema.Field::name)
+    assertEquals(expectedFields, actualFieldNames)
+
+    val schemaByDescriptor = ProtobufData.get().getSchema(GetFortuneRequest.getDescriptor())
+    assertEquals(schemaByClass, schemaByDescriptor)
+  }
+
+  @Test
+  fun `should roundtrip a Protobuf via Avro`() {
+    val sourceGetFortune = GrpcProtoBuilders.GetFortuneRequest {
+      name = "Request1"
+      optionalCar = GrpcProtoBuilders.GetFortuneRequest.Car {
+        make = "Geo"
+        model = "Metro"
+        year = 1992
+      }
+      carNickname = "Greatest. Car. Ever."
+      addAllFingerLengths(listOf(42, 24))
+      putAllSiblingAges(mapOf(
+        "Larry" to 30,
+        "Moe" to 31,
+        "Curly" to 32
+      ))
+    }
+
+    val getFortuneRequestSchema = ProtobufData.get().getSchema(GetFortuneRequest.getDescriptor())
+
+    // Binary streams to write to, then read from
+    val outputStream = PipedOutputStream()
+    val inputStream = PipedInputStream(outputStream)
+
+    // binary en/de-coders for writing to and reading from streams
+    val binaryEncoder = EncoderFactory.get().binaryEncoder(outputStream, null)
+    val binaryDecoder = DecoderFactory.get().binaryDecoder(inputStream, null)
+
+    // Avro writer and reader
+    val datumWriter = ProtobufData.get().createDatumWriter(getFortuneRequestSchema)
+    val datumReader = ProtobufData.get().createDatumReader(getFortuneRequestSchema)
+
+    // WHEN we write the source and read it back out
+    datumWriter.write(sourceGetFortune, binaryEncoder)
+    binaryEncoder.flush()
+    outputStream.flush()
+    outputStream.close()
+    val readGetFortune = datumReader.read(null, binaryDecoder)
+
+    // Source and Read values should be equal
+    assertEquals(sourceGetFortune, readGetFortune)
+    println(readGetFortune)
+  }
+}

--- a/kotlin/kroto-plus/protobuf-avro/src/test/kotlin/com/spothero/krotoplus/protobufavro/ProtobufOverAvroTest.kt
+++ b/kotlin/kroto-plus/protobuf-avro/src/test/kotlin/com/spothero/krotoplus/protobufavro/ProtobufOverAvroTest.kt
@@ -33,34 +33,6 @@ class ProtobufOverAvroTest {
 
     val schemaByDescriptor = ProtobufData.get().getSchema(GetFortuneRequest.getDescriptor())
     assertEquals(schemaByClass, schemaByDescriptor)
-
-    val siblingAgesField = schemaByClass.getField("sibling_ages")
-    println("field: $siblingAgesField")
-    println("schema: ${siblingAgesField.schema()}")
-
-    val siblingAgesSchema = ProtobufData.get()
-      .getSchema(GetFortuneRequest.getDescriptor().findFieldByName("sibling_ages"))
-    println("siblingAgesSchema: $siblingAgesSchema")
-
-    val schemaCacheField = ProtobufData::class.java.getDeclaredField("schemaCache")
-    schemaCacheField.trySetAccessible()
-    val schemaCache = schemaCacheField.get(ProtobufData.get()) as Map<Object, Schema>
-    for (entry in schemaCache.entries) {
-      println("obj: ${entry.key}, schema: ${entry.value.name}")
-    }
-    val schemaCacheSize = schemaCache.size
-    println("Original schemaCache size: $schemaCacheSize")
-
-    for (fieldDescriptor in GetFortuneRequest.getDescriptor().fields) {
-      println("fieldDescriptor: $fieldDescriptor, type: ${fieldDescriptor.type}, isRepeated: ${fieldDescriptor.isRepeated}")
-      if (fieldDescriptor.isMapField) {
-        println("mapField: $fieldDescriptor, messageType: ${fieldDescriptor.messageType.name}")
-        val mapElementSchema = ProtobufData.get().getSchema(fieldDescriptor.messageType)
-        println("mapElementSchema: $mapElementSchema")
-        val newSchemaCacheSize = schemaCache.size
-        println("New schemaCache size: $newSchemaCacheSize")
-      }
-    }
   }
 
   @Test
@@ -107,6 +79,5 @@ class ProtobufOverAvroTest {
     val readGetFortune = datumReader.read(null, binaryDecoder)
     // Source and Read values should be equal
     assertEquals(sourceGetFortune, readGetFortune)
-    println(readGetFortune)
   }
 }

--- a/kotlin/kroto-plus/settings.gradle.kts
+++ b/kotlin/kroto-plus/settings.gradle.kts
@@ -18,5 +18,6 @@ include(
   ":coroutine-client",
   ":coroutine-server",
   ":micronaut-grpc",
-  ":drophero"
+  ":drophero",
+  ":protobuf-avro"
 )


### PR DESCRIPTION
Provides examples (tests) for getting an Avro schema from a Protobuf Message class or Descriptor.  Also provides an example of serializing a message to Avro binary and back.

This example proves out that we _should_ be able to serialize a Protobuf message into Kafka as an Avro binary, treat it like regular Avro data in subsequent Kafka processing (streaming, ksql, etc), and deserialize that data back into its original Protobuf form.

There is a big bug/functional gap in Avro's protobuf handling library--it can't properly handle Protobuf maps.  In my free time I'm going to poke around the source code.  If it's straight-forward I'll open a PR to close this gap.  If it's complicated I'll open an issue.

This was a discovery day exploration.  For my next step, I would like to create a basic Dockerized Kafka stack and try to view the data once it has been serialized and pushed to a topic.